### PR TITLE
 improved detection of distro_name()

### DIFF
--- a/patchwork/info.py
+++ b/patchwork/info.py
@@ -1,12 +1,15 @@
+from fabric.api import run, hide
 from fabric.contrib.files import exists
+from patchwork.environment import has_binary
 
 
 def distro_name():
     """
     Return simple Linux distribution name identifier, e.g. ``"fedora"``.
 
-    Uses tools like ``/etc/issue``, and ``lsb_release`` and fits the remote
-    system into one of the following:
+    Uses files like ``/etc/os-release`` (or ``/etc/*-release``) and
+    tools like ``/etc/issue``, and ``lsb_release``, trying to identify
+    short id of the system. Examples:
 
     * ``fedora``
     * ``rhel``
@@ -15,11 +18,37 @@ def distro_name():
     * ``debian``
     * ``other``
     """
-    sentinel_files = {
-        'fedora': ('fedora-release',),
-        'centos': ('centos-release',),
-    }
-    for name, sentinels in sentinel_files.iteritems():
+    with hide('running', 'stdout'):
+        if has_binary('lsb_release'):
+            distro_id = run('lsb_release -s -i').strip().lower()
+            if distro_id:
+                return distro_id
+
+        if exists('/etc/lsb-release'):
+            distro_id = run('''awk -F '=' '$1 == "DISTRIB_ID" \
+                {print $2; exit }' \
+                /etc/lsb-release ''',
+            shell=False).strip().lower()
+            if distro_id:
+                return distro_id
+
+        if exists('/etc/os-release'):
+            distro_id = run('''awk -F '=' '$1 == "ID" \
+                {print $2; exit }' \
+                /etc/os-release''',
+            shell=False).strip().lower()
+            if distro_id:
+                return distro_id
+
+    # and now the fallback method (guess by existing files)
+    sentinel_files = (
+        ('fedora', ('fedora-release',)),
+        ('centos', ('centos-release',)),
+        ('debian', ('debian_version',)),
+        ('gentoo', ('gentoo-release',)),
+    )
+
+    for name, sentinels in sentinel_files:
         for sentinel in sentinels:
             if exists('/etc/%s' % sentinel):
                 return name
@@ -34,7 +63,7 @@ def distro_family():
 
     * ``debian``
     * ``redhat``
-    
+
     If the system falls outside these categories, its specific family or
     release name will be returned instead.
     """


### PR DESCRIPTION
using executable lsb_release
      or files:
            /etc/lsb-release
            /etc/os-release

to determine short distro id

also adding  debian_version  to sentinel files - allowing fallback
detection of debian (or derived) system.
