### PR TITLE
Fix formatted string params

### DIFF
--- a/patchwork/transfers.py
+++ b/patchwork/transfers.py
@@ -116,7 +116,7 @@ def rsync(
     # Set up options part of string
     options_map = {
         "delete": "--delete" if delete else "",
-        "exclude": exclude_opts.format(exclusions),
+        "exclude": exclude_opts.format(*exclusions),
         "rsh": rsh_string,
         "extra": rsync_opts,
     }


### PR DESCRIPTION
Was having issues with the exclude param, and it was (basically) trying to call `"--exclude {} --exclude {}".format((a,b))` which gave me `tuple index out of range`