### PR TITLE
support rsync from remote to local 

### DIFF
--- a/patchwork/_version.py
+++ b/patchwork/_version.py
@@ -1,2 +1,2 @@
-__version_info__ = (1, 0, 1)
+__version_info__ = (1, 0, 2)
 __version__ = ".".join(map(str, __version_info__))

--- a/patchwork/transfers.py
+++ b/patchwork/transfers.py
@@ -14,6 +14,7 @@ def rsync(
     strict_host_keys=True,
     rsync_opts="",
     ssh_opts="",
+    remote_to_local=False,
 ):
     """
     Convenient wrapper around your friendly local ``rsync``.
@@ -77,6 +78,9 @@ def rsync(
     :param str ssh_opts:
         Like ``rsync_opts`` but specifically for the SSH options string
         (rsync's ``--rsh`` flag.)
+    :param bool remote_to_local:
+        boolean flag that indicate whether you want to sync from remote to local.
+        By default it is sync from local to remote.
     """
     # Turn single-string exclude into a one-item list for consistency
     if isinstance(exclude, six.string_types):
@@ -126,8 +130,14 @@ def rsync(
     if host.count(":") > 1:
         # Square brackets are mandatory for IPv6 rsync address,
         # even if port number is not specified
-        cmd = "rsync {} {} [{}@{}]:{}"
+        if remote_to_local:
+            cmd = "rsync {options} [{user}@{host}]:{target} {source}"
+        else:
+            cmd = "rsync {options} {source} [{user}@{host}]:{target}"
     else:
-        cmd = "rsync {} {} {}@{}:{}"
-    cmd = cmd.format(options, source, user, host, target)
+        if remote_to_local:
+            cmd = "rsync {options} {user}@{host}:{target} {source}"
+        else:
+            cmd = "rsync {options} {source} {user}@{host}:{target}"
+    cmd = cmd.format(options=options, source=source, user=user, host=host, target=target)
     return c.local(cmd)

--- a/patchwork/transfers.py
+++ b/patchwork/transfers.py
@@ -139,5 +139,11 @@ def rsync(
             cmd = "rsync {options} {user}@{host}:{target} {source}"
         else:
             cmd = "rsync {options} {source} {user}@{host}:{target}"
-    cmd = cmd.format(options=options, source=source, user=user, host=host, target=target)
+    cmd = cmd.format(
+        options=options,
+        source=source,
+        user=user,
+        host=host,
+        target=target,
+    )
     return c.local(cmd)

--- a/patchwork/transfers.py
+++ b/patchwork/transfers.py
@@ -79,8 +79,8 @@ def rsync(
         Like ``rsync_opts`` but specifically for the SSH options string
         (rsync's ``--rsh`` flag.)
     :param bool remote_to_local:
-        boolean flag that indicate whether you want to sync from remote to local.
-        By default it is sync from local to remote.
+        boolean flag that indicate whether you want to sync from
+        remote to local. By default it is sync from local to remote.
     """
     # Turn single-string exclude into a one-item list for consistency
     if isinstance(exclude, six.string_types):


### PR DESCRIPTION
fix #26 

The method is simple. Just add an argument `remote_to_local` to `transfers.rsync` function.

If the flag is True, then switch the source and target in the command template. And use keyword arguments instead of positioning argument style.

Solution:

```python
    if host.count(":") > 1:
        # Square brackets are mandatory for IPv6 rsync address,
        # even if port number is not specified
        if remote_to_local:
            cmd = "rsync {options} [{user}@{host}]:{target} {source}"
        else:
            cmd = "rsync {options} {source} [{user}@{host}]:{target}"
    else:
        if remote_to_local:
            cmd = "rsync {options} {user}@{host}:{target} {source}"
        else:
            cmd = "rsync {options} {source} {user}@{host}:{target}"
    cmd = cmd.format(options=options, source=source, user=user, host=host, target=target)
    return c.local(cmd)
```