### PR TITLE
fix : append something to a file when sudo

### DIFF
--- a/patchwork/files.py
+++ b/patchwork/files.py
@@ -127,7 +127,8 @@ def append(c, runner, filename, text, partial=False, escape=True):
         ):
             continue
         line = line.replace("'", r"'\\''") if escape else line
-        runner("echo '{}' >> {}".format(line, filename))
+        # runner("echo '{}' >> {}".format(line, filename))
+        runner('''bash -c "echo '{}' >> {}" '''.format(line, filename))
 
 
 def _escape_for_regex(text):


### PR DESCRIPTION
1. I met this error
INFO:paramiko.transport:Authentication (password) successful!
bash: /root/.ssh/authorized_keys: 权限不够
ERROR:root:Encountered a bad command exit code!
Command: "sudo -S -p '[sudo] password: ' echo 'ssh-rsa  a_very_long_string  root@s1' >> /root/.ssh/authorized_keys"
Exit code: 1

2. when I excute the follow command manually, it passed.
sudo -S -p '[sudo] password: ' bash -c "echo 'ssh-rsa  a_very_long_string  root@s1' >> /root/.ssh/authorized_keys "

3. the reason is that `` >> /root/.ssh/authorized_keys`` doesn't have sudo priviledge.
So we need  ``bash -c "a_long_command" `` to wrap them up.